### PR TITLE
Allow to use environments variables as presets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,12 @@ RUN curl -o srdb.zip -L https://github.com/interconnectit/Search-Replace-DB/arch
     rm srdb.zip; \
     mv Search-Replace-DB-3.1/* .; \
     rmdir Search-Replace-DB-3.1
+RUN sed -i '/$this->response();/ i\
+    $name = getenv("DB_NAME") ?: NULL;\
+    $user = getenv("DB_USER") ?: NULL;\
+    $pass = getenv("DB_PASS") ?: NULL;\
+    $host = getenv("DB_HOST") ?: "127.0.0.1";\
+    $port = getenv("DB_PORT") ?: "3306";\
+    $charset = getenv("DB_CHARSET") ?: "utf8";\
+    $collate = getenv("DB_COLLATE") ?: "";' ./index.php
+RUN sed -i "s/\$this->response();/\$this->response(\$name, \$user, \$pass, \$host, \$port, \$charset, \$collate);/g" ./index.php

--- a/README.md
+++ b/README.md
@@ -10,3 +10,40 @@ The [Search-Replace-DB project](https://github.com/interconnectit/Search-Replace
 docker run -p 8000:80 --link mysql \
        foxylion/search-replace-db
 ```
+
+You can pass environment variables to the image to prefill database informations : 
+
+```
+docker run -p 8000:80 --link mysql \
+-e DB_NAME='mydb' \
+-e DB_user='myuser' \
+-e DB_PASS= 'mypassword' \
+ foxylion/search-replace-db
+```
+
+An example within a docker-compose.yml file : 
+```
+  srdb:
+    image: kgaut/docker-search-replace-db
+    container_name: "srdb"
+    labels:
+      - 'traefik.backend=srdb'
+      - 'traefik.port=80'
+      - 'traefik.frontend.rule=Host:srdb.localhost'
+    environment:
+      DB_HOST: 'mariadb'
+      DB_USER: 'myuser'
+      DB_PASS: 'mypassword'
+      DB_NAME: 'database'
+```
+
+
+Full list of environment variables :
+
+  - `DB_NAME` (default to "")
+  - `DB_USER` (default to "")
+  - `DB_PASS` (default to "")
+  - `DB_HOST` (default to "127.0.0.1")
+  - `DB_PORT` (default to "3306")
+  - `DB_CHARSET` (default to "utf-8")
+  - `DB_COLLATE` (default to "")


### PR DESCRIPTION
Addressing #1 

The solution is not very neat, as it edit srdb's `index.php` file. But it works !

Usage examples : 
```
docker run -p 8000:80 --link mysql \
-e DB_NAME='mydb' \
-e DB_user='myuser' \
-e DB_PASS= 'mypassword' \
 kgaut/docker-search-replace-db
```

or with docker-compose : 

```
  srdb:
    image: kgaut/docker-search-replace-db
    container_name: "srdb"
    labels:
      - 'traefik.backend=srdb'
      - 'traefik.port=80'
      - 'traefik.frontend.rule=Host:srdb.localhost'
    environment:
      DB_HOST: $DB_HOST
      DB_USER: $DB_USER
      DB_PASS: $DB_PASSWORD
      DB_NAME: $DB_NAME
```

full list of environment variables : 

  - DB_NAME (default to "")
  - DB_USER (default to "")
  - DB_PASS (default to "")
  - DB_HOST (default to "127.0.0.1")
  - DB_PORT (default to "3306")
  - DB_CHARSET (default to "utf-8")
  - DB_COLLATE (default to "")
